### PR TITLE
Add tests for solcheck CLI

### DIFF
--- a/src/gurobi_modelanalyzer/solcheck.py
+++ b/src/gurobi_modelanalyzer/solcheck.py
@@ -233,7 +233,6 @@ class SolCheck:
 def main_cli():
     import argparse
     import gurobipy as gp
-    import questionary as qy
 
     parser = argparse.ArgumentParser(
         prog="gurobi_solcheck", description="Check if a solution is feasible"
@@ -266,6 +265,8 @@ def main_cli():
     if args.model:
         mfn = args.model
     else:
+        import questionary as qy
+
         print("Entering interactive mode")
         mfn = qy.path(
             "Select a model file",

--- a/tests/test_solcheck.py
+++ b/tests/test_solcheck.py
@@ -136,17 +136,13 @@ class TestSolCheckCLI(TestCase):
             result,
         )
         self.assertIn(
-            "Solution is infeasible for feasibility tolerance of 1e-06",
-            result,
+            "Solution is infeasible for feasibility tolerance of 1e-06", result
         )
         self.assertIn(
             "Relaxing to find smallest violation from fixed solution",
             result,
         )
-        self.assertIn(
-            "Fixed values are 1.5 from a feasible solution",
-            result,
-        )
+        self.assertIn("Fixed values are 1.5 from a feasible solution", result)
 
     def test_infeasible_solution_infmethodV(self):
         misc07fix_sol_file = cwd.joinpath("misc07fix.sol")
@@ -160,18 +156,12 @@ class TestSolCheckCLI(TestCase):
         self.assertTrue(misc07fix_sol_file.exists())
 
         # Check log for expected output
-        self.assertIn(
-            "Model is infeasible",
-            result,
-        )
+        self.assertIn("Model is infeasible", result)
         self.assertIn(
             "Relaxing to find smallest violation from fixed solution",
             result,
         )
-        self.assertIn(
-            "Fixed values are 409.5 from a feasible solution",
-            result,
-        )
+        self.assertIn("Fixed values are 409.5 from a feasible solution", result)
 
     def test_infeasible_solution_infmethodI(self):
         misc07fix_ilp_file = cwd.joinpath("misc07fix.ilp")
@@ -185,15 +175,12 @@ class TestSolCheckCLI(TestCase):
         self.assertTrue(misc07fix_ilp_file.exists())
 
         # Check log for expected output
+        self.assertIn("Model is infeasible", result)
         self.assertIn(
-            "Model is infeasible",
-            result,
-        )
-        self.assertIn(
-            "Solution is infeasible for feasibility tolerance of 1e-06",
-            result,
+            "Solution is infeasible for feasibility tolerance of 1e-06", result
         )
         self.assertIn(
             "Computing Irreducible Inconsistent Subsystem (IIS)",
             result,
         )
+        self.assertIn("IIS computed: 1 constraints, 2 bounds", result)

--- a/tests/test_solcheck.py
+++ b/tests/test_solcheck.py
@@ -120,6 +120,28 @@ class TestSolCheckCLI(TestCase):
 
         self.assertEqual(self.afirofix_md5, md5_ret)
 
+    def test_suboptimal_json_solution(self):
+        afirofix_file = cwd.joinpath("afirofix.sol")
+        self.assertFalse(afirofix_file.exists())
+        cmd = (
+            f"gurobi_solcheck --model {str(here / 'dataset' / 'afiro.mps')} "
+            + f"--sol {str(here / 'dataset' / 'afiro.json')} --result afirofix"
+        )
+        result = subprocess.getoutput(cmd)
+        self.assertIn(
+            "Solution is feasible for feasibility tolerance of 1e-06",
+            result,
+        )
+        self.assertIn("Difference: -5.0613", result)
+        self.assertTrue(afirofix_file.exists())
+
+        md5_ret = None
+        with open(afirofix_file, "rb") as f:
+            d = f.read()
+            md5_ret = hashlib.md5(d).hexdigest()
+
+        self.assertEqual(self.afirofix_md5, md5_ret)
+
     def test_infeasible_solution(self):
         misc07fix_vio_file = cwd.joinpath("misc07fix.vio")
         self.assertFalse(misc07fix_vio_file.exists())


### PR DESCRIPTION
> @torressa : To test the CLI, you could run in batch mode (with the --model flag), send the output to a temp file, and do a checksum like md5 on that output.
> 
> That said, I'm confused why you included afiro.mps and misc07.mps (which are part of the standard Gurobi distribution, though not gurobipy) while you didn't include the sample files afiro.{sol,json} and misc07.sol.

From @gglockner https://github.com/Gurobi/gurobi-modelanalyzer/pull/6#issuecomment-2356548373

Thanks Greg! That's a good shout. I didn't add the `sol` files as they are only needed to test the CLI which I didn't manage in the previous PR. This PR adds the tests for the CLI. 

The only thing with the md5sum check is that for different seeds we may get different equivalent solutions. Therefore I've only added a checksum test for the suboptimal solution test (using the afiro model). For the others checking for the expected log outputs and files should be fine I reckon.