### PR TITLE
Changes for v12

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -62,7 +62,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement
-[here](https://gurobi-optimization-gurobi-modelanalyzer.readthedocs-hosted.com/en/latest/contactus.html).  
+[here](https://gurobi-modelanalyzer.readthedocs.io/en/latest/contactus.html).
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ interactive = [
 ]
 
 [project.urls]
-Documentation = "https://gurobi-optimization-gurobi-modelanalyzer.readthedocs-hosted.com/en/latest"
+Documentation = "https://gurobi-modelanalyzer.readthedocs.io/en/latest/"
 Issues = "https://github.com/Gurobi/gurobi-modelanalyzer/issues"
 Source = "https://github.com/Gurobi/gurobi-modelanalyzer"
 


### PR DESCRIPTION
Ignore most of the diff in the python file, it is just black formatting. The important ones in changing `m.addConstr(lhs, sense, ...)` to `m.addLConstr` as the former was deprecated and now removed in v12 ([here](https://github.com/Gurobi/gurobi-modelanalyzer/pull/11/files#diff-ea9fa431d71118e7f788912adec5555b7f651f97996b8f16b6220dfe01e3193fL899) and [here](https://github.com/Gurobi/gurobi-modelanalyzer/pull/11/files#diff-ea9fa431d71118e7f788912adec5555b7f651f97996b8f16b6220dfe01e3193fL1642))

@mattmilten please check this and trigger a release, can wait until v12