### PR TITLE
Allow custom filename for kappa_explain

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ gma.kappa_explain(model, expltype="ROWS")
 # column-based explanation
 gma.kappa_explain(model, expltype="COLS")
 
+# custom output file name
+gma.kappa_explain(model, filename="myname.lp")
+
 # angle-based explanation (only looks for pairs of rows or columns
 # that cause ill-conditioning.
 gma.angle_explain(model)
@@ -139,6 +142,16 @@ Other useful resources to get started:
 We value any level of experience in using Gurobi Model Analyzer and would like to encourage you to
 contribute directly to this project. Please see the [Contributing Guide](CONTRIBUTING.md) for more information.
 
+
+## Running the tests
+Install the package and execute the unit tests from the project root:
+
+```console
+python -m pip install .
+python -m unittest discover -v
+```
+
+This runs all tests under the `tests/` directory.
 
 ## Submitting a Pull Request
 Before opening a Pull Request, have a look at the full

--- a/docs/source/apiref_illcond.rst
+++ b/docs/source/apiref_illcond.rst
@@ -6,7 +6,7 @@ API Reference
 
 .. _APIkappa_explainLabel:
 
-.. py:function:: gurobi_modelanalyzer.kappa_explain(model, data=None, KappaExact=-1, prmfile=None, relobjtype="LP", expltype="ROWS", method="DEFAULT", smalltol=1e-13, submatrix=False)
+.. py:function:: gurobi_modelanalyzer.kappa_explain(model, data=None, KappaExact=-1, prmfile=None, relobjtype="LP", expltype="ROWS", method="DEFAULT", smalltol=1e-13, submatrix=False, filename=None)
 
    Computes an explanation of ill conditioning for the basis matrix associated
    with the LP model in the first argument.   Writes the explanation to an LP
@@ -39,6 +39,8 @@ API Reference
 		      "RLS":       Two norm regularization of subproblem objective.
    :param smalltol:   Optional tolerance below which ill conditioning certificate values are all treated as zero, i.e., the row or column associated with the value is filtered out of the explanation.  If left at the default of 1e-13, row or column norms and machine precision will be incorporated into the filtering decision.
    :param submatrix:  Optional flag to try to postprocess the explanation down to a smaller submatrix.   Default is False.
+   :param filename:   Optional name of the file that will contain the explanation.  If omitted, the
+                      file name is derived from the model name and the explanation type.
    :return:           A Gurobi model object containing the basis matrix rows or columns in the explanation that was written to an LP or MPS file.
 
 .. _APIangle_explainLabel:

--- a/docs/source/quickstart_illcond.rst
+++ b/docs/source/quickstart_illcond.rst
@@ -77,6 +77,8 @@ file format.  Row based explanations are written in LP format, while column
 based explanations are written in MPS format.   The file name consists of
 the name of the model as specified in the gurobipy ``Model.modelName`` attribute,
 suffixed by ``"_kappaexplain"``, followed by the file format (.lp or .mps).
+You can override this default by providing a ``filename`` argument to
+``kappa_explain``.
 The method also returns the model associated with the LP or MPS file that
 was written.
 

--- a/src/gurobi_modelanalyzer/results_analyzer.py
+++ b/src/gurobi_modelanalyzer/results_analyzer.py
@@ -51,6 +51,7 @@ def kappa_explain(
     method="DEFAULT",
     smalltol=DEFSMALLTOL,
     submatrix=False,
+    filename=None,
 ):
     #
     #   Help function info
@@ -92,6 +93,10 @@ def kappa_explain(
                           machine precision will be incorporated.
     submatrix  (optional) Whether to postprocess the explanation down to
                           a smaller submatrix.  Default is False.
+    filename   (optional) Name of the file to which the explanation is
+                          written.  By default the name consists of the
+                          model name suffixed by "_kappaexplain" with an
+                          extension determined by the explanation type.
     Returns:              For all method settings except ANGLES, returns
                           the model that consists of the explanation.
                           If the method is ANGLES, returns a list of tuples
@@ -176,7 +181,7 @@ def kappa_explain(
         # routine to create the explanation.
         #
         resmodel, maxmult, minmult = build_singleton_resmodel(explmodel, expltype)
-        illcond_report(resmodel, model.ModelName, expltype, maxmult, minmult)
+        illcond_report(resmodel, model.ModelName, expltype, maxmult, minmult, filename)
         return resmodel
     #
     #   Minimize the violations of B'y = 0 constraints.  Do not relax
@@ -526,6 +531,7 @@ def kappa_explain(
         expltype,
         max(yvaldict.values()),
         min(yvaldict.values()),
+        filename,
     )
     if method == ANGLES:
         return ([], [], None)  # Compatibility with method=ANGLES
@@ -1110,14 +1116,15 @@ def kappa_stats(model, data, KappaExact):
 #
 #   Write out the final explanation, print summary info.
 #
-def illcond_report(resmodel, modelname, expltype, maxabsmult, minabsmult):
+def illcond_report(resmodel, modelname, expltype, maxabsmult, minabsmult, filename=None):
     resmodel.setObjective(0)
-    if modelname == "":
-        modelname = "model"
-    if expltype == BYROWS:
-        filename = modelname + "_kappaexplain.lp"
-    else:
-        filename = modelname + "_kappaexplain.mps"
+    if filename is None:
+        if modelname == "":
+            modelname = "model"
+        if expltype == BYROWS:
+            filename = modelname + "_kappaexplain.lp"
+        else:
+            filename = modelname + "_kappaexplain.mps"
     resmodel.write(filename)
     #
     #   Final info

--- a/tests/test_explainer.py
+++ b/tests/test_explainer.py
@@ -29,6 +29,7 @@ class TestExplainer(unittest.TestCase):
         output_files = [
             cwd.joinpath("testmodel_kappaexplain.lp"),
             cwd.joinpath("testmodel_kappaexplain.mps"),
+            cwd.joinpath("myname.lp"),
         ]
         for file in output_files:
             if file.exists():
@@ -80,6 +81,12 @@ class TestExplainer(unittest.TestCase):
         lpfile = cwd.joinpath("testmodel_kappaexplain.lp")
         assert not lpfile.exists()
         kappa_explain(self.model, submatrix=True)
+        assert lpfile.exists()
+
+    def test_custom_filename(self):
+        lpfile = cwd.joinpath("myname.lp")
+        assert not lpfile.exists()
+        kappa_explain(self.model, filename="myname.lp")
         assert lpfile.exists()
 
     #


### PR DESCRIPTION
## Summary
- allow specifying output filename in `kappa_explain`
- document new argument in README and docs
- update quickstart details about default file naming
- test custom filename capability

## Testing
- `python -m unittest discover -v`
